### PR TITLE
feat: add dark and light mode toggle

### DIFF
--- a/next-app/app/_components/layouts/Header.tsx
+++ b/next-app/app/_components/layouts/Header.tsx
@@ -1,6 +1,8 @@
 'use client';
 import { useRouter } from 'next/navigation';
 
+import ToggleModeCheckbox from './ToggleModeCheckbox';
+
 interface HeaderProps {
   appName: string;
   homePath: string;
@@ -25,8 +27,8 @@ export default function Header(props: HeaderProps) {
             {props.appName}
           </button>
         </div>
-        <div className="navbar-end">
-          <button className="btn btn-primary">Primary</button>
+        <div className="navbar-end mr-3">
+          <ToggleModeCheckbox />
         </div>
       </div>
     </header>

--- a/next-app/app/_components/layouts/ToggleModeCheckbox.tsx
+++ b/next-app/app/_components/layouts/ToggleModeCheckbox.tsx
@@ -1,0 +1,37 @@
+'use client';
+import { useState, useEffect } from 'react';
+
+import { useTheme } from 'next-themes';
+import { Moon, Sun } from '@phosphor-icons/react';
+
+export default function ToggleModeCheckbox() {
+  const [mounted, setMounted] = useState(false);
+  const { theme, setTheme } = useTheme();
+
+  // useEffect only runs on the client, so now we can safely show the UI
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) {
+    return null;
+  }
+
+  function toggleTheme() {
+    setTheme(theme === 'night' ? 'cupcake' : 'night');
+  }
+
+  return (
+    <label className="btn btn-circle btn-ghost swap swap-rotate">
+      <input
+        type="checkbox"
+        id="themeToggle"
+        name="themeToggle"
+        onChange={toggleTheme}
+        checked={theme === 'night'}
+      />
+      <Sun className="swap-off" width="32" height="32" />
+      <Moon className="swap-on" width="32" height="32" />
+    </label>
+  );
+}

--- a/next-app/app/_providers/GlobalProviders.tsx
+++ b/next-app/app/_providers/GlobalProviders.tsx
@@ -1,0 +1,18 @@
+'use client';
+import React from 'react';
+
+import { ThemeProvider } from 'next-themes';
+
+export default function GlobalProviders({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <ThemeProvider defaultTheme="night" themes={['cupcake', 'night']}>
+        {children}
+      </ThemeProvider>
+    </>
+  );
+}

--- a/next-app/app/layout.tsx
+++ b/next-app/app/layout.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from 'next';
 import { Noto_Sans_JP } from 'next/font/google';
 import './globals.css';
 
+import GlobalProviders from './_providers/GlobalProviders';
+
 import Header from './_components/layouts/Header';
 import Footer from './_components/layouts/Footer';
 
@@ -22,23 +24,25 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="jp">
+    <html lang="jp" suppressHydrationWarning>
       <body
         className={`${notoSansJp.className} flex flex-col h-screen w-screen`}
       >
-        <Header
-          appName={metadata.title?.toString() ?? 'NakuRei'}
-          homePath="/"
-          className="bg-base-300 text-base-content"
-        />
-        <main className="flex flex-col flex-1 justify-center items-center overflow-x-hidden">
-          {children}
-        </main>
-        <Footer
-          authorName="NakuRei"
-          year={2023}
-          className="bg-base-300 text-base-content"
-        />
+        <GlobalProviders>
+          <Header
+            appName={metadata.title?.toString() ?? 'NakuRei'}
+            homePath="/"
+            className="bg-base-300 text-base-content"
+          />
+          <main className="flex flex-col flex-1 justify-center items-center overflow-x-hidden">
+            {children}
+          </main>
+          <Footer
+            authorName="NakuRei"
+            year={2023}
+            className="bg-base-300 text-base-content"
+          />
+        </GlobalProviders>
       </body>
     </html>
   );

--- a/next-app/tailwind.config.ts
+++ b/next-app/tailwind.config.ts
@@ -16,5 +16,9 @@ const config: Config = {
     },
   },
   plugins: [require('daisyui')],
+  daisyui: {
+    themes: ['cupcake', 'night'],
+    logs: !process.env.CI,
+  },
 };
 export default config;


### PR DESCRIPTION
Implemented a theme toggle using the existing `next-themes` setup. The toggle allows users to switch between dark and light mode from the navigation bar. The current theme is persisted across sessions.

Closes #1