### PR TITLE
fix: prevent main content cut-off when vertically long

### DIFF
--- a/next-app/app/layout.tsx
+++ b/next-app/app/layout.tsx
@@ -34,7 +34,7 @@ export default function RootLayout({
             homePath="/"
             className="bg-base-300 text-base-content"
           />
-          <main className="flex flex-col flex-1 justify-center items-center overflow-x-hidden">
+          <main className="flex-1 overflow-x-hidden overflow-y-scroll">
             {children}
           </main>
           <Footer

--- a/next-app/app/page.tsx
+++ b/next-app/app/page.tsx
@@ -1,9 +1,51 @@
 export default function Home() {
   return (
-    <div>
+    <div className="flex flex-col justify-center items-center">
+      main1 <br />
+      main2 <br />
+      main3 <br />
       main <br />
       main <br />
       main <br />
+      main <br />
+      main <br />
+      main <br />
+      main <br />
+      main <br />
+      main <br />
+      main <br />
+      main <br />
+      main <br />
+      main <br />
+      main <br />
+      main <br />
+      main <br />
+      main <br />
+      main <br />
+      main <br />
+      main <br />
+      main <br />
+      main <br />
+      main <br />
+      main <br />
+      main <br />
+      main <br />
+      main <br />
+      main <br />
+      main <br />
+      main <br />
+      main <br />
+      main <br />
+      main <br />
+      main <br />
+      main <br />
+      main <br />
+      main <br />
+      main <br />
+      main <br />
+      main3 <br />
+      main2 <br />
+      main1 <br />
     </div>
   );
 }


### PR DESCRIPTION
This commit ensures that the main content is no longer cut off at the top when it extends beyond the vertical length of the page.

Closes #3