### PR TITLE
feat(footer): add social links and Rakuten credit

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-  "cSpell.words": ["NakuRei", "Rakuten"],
+  "cSpell.words": ["NakuRei", "Rakuten", "Zenn"],
   "editor.quickSuggestions": {
     "strings": true
   },

--- a/next-app/app/_components/layouts/Footer.tsx
+++ b/next-app/app/_components/layouts/Footer.tsx
@@ -1,3 +1,9 @@
+'use client';
+import { GithubLogo, NotePencil, TwitterLogo } from '@phosphor-icons/react';
+
+import IconLinkButton from './IconLinkButton';
+import ZennLogoButton from './ZennLogoButton';
+
 interface FooterProps {
   authorName: string;
   year: number;
@@ -6,12 +12,39 @@ interface FooterProps {
 
 export default function Footer(props: FooterProps) {
   return (
-    <footer className={`${props.className} footer footer-center p-4`}>
-      <aside>
+    <footer className={`${props.className} footer items-center p-4`}>
+      <aside className="items-center grid-flow-row">
         <p>
           © {props.year} {props.authorName}
         </p>
+
+        {/* <!-- Rakuten Web Services Attribution Snippet FROM HERE --> */}
+        <a href="https://developers.rakuten.com/" target="_blank">
+          Supported by Rakuten Developers
+        </a>
+        {/* <!-- Rakuten Web Services Attribution Snippet TO HERE --> */}
       </aside>
+      <nav className="grid-flow-col gap-1 md:place-self-center md:justify-self-end">
+        <IconLinkButton
+          href="https://github.com/NakuRei"
+          ariaLabel="Visit GitHub page"
+        >
+          <GithubLogo size={32} />
+        </IconLinkButton>
+        <ZennLogoButton />
+        <IconLinkButton
+          href="https://notes.nakurei.com"
+          ariaLabel="Visit Tech blog"
+        >
+          <NotePencil size={32} />
+        </IconLinkButton>
+        <IconLinkButton
+          href="https://twitter.com/nakurei7901"
+          ariaLabel="Visit Twitter"
+        >
+          <TwitterLogo size={32} />
+        </IconLinkButton>
+      </nav>
     </footer>
   );
 }

--- a/next-app/app/_components/layouts/IconLinkButton.tsx
+++ b/next-app/app/_components/layouts/IconLinkButton.tsx
@@ -1,0 +1,19 @@
+interface IconLinkButtonProps {
+  href: string;
+  ariaLabel: string;
+  children: React.ReactNode;
+}
+
+export default function IconLinkButton(props: IconLinkButtonProps) {
+  return (
+    <a
+      className="btn btn-circle btn-ghost"
+      href={props.href}
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label={props.ariaLabel}
+    >
+      {props.children}
+    </a>
+  );
+}

--- a/next-app/app/_components/layouts/ZennLogoButton.tsx
+++ b/next-app/app/_components/layouts/ZennLogoButton.tsx
@@ -1,0 +1,33 @@
+export default function ZennLogoButton() {
+  return (
+    <a
+      className="btn btn-circle btn-ghost"
+      href="https://zenn.dev/nakurei"
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label="Visit Zenn page"
+    >
+      <svg
+        width={32}
+        height={32}
+        viewBox="0 0 88.3 88.3"
+        fill="none"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="5.5"
+      >
+        <g>
+          <path
+            d="M3.9,83.3h17c0.9,0,1.7-0.5,2.2-1.2L69.9,5.2c0.6-1-0.1-2.2-1.3-2.2H52.5c-0.8,0-1.5,0.4-1.9,1.1L3.1,81.9
+		C2.8,82.5,3.2,83.3,3.9,83.3z"
+          />
+          <path
+            d="M62.5,82.1l22.1-35.5c0.7-1.1-0.1-2.5-1.4-2.5h-16c-0.6,0-1.2,0.3-1.5,0.8L43,81.2c-0.6,0.9,0.1,2.1,1.2,2.1
+		h16.3C61.3,83.3,62.1,82.9,62.5,82.1z"
+          />
+        </g>
+      </svg>
+    </a>
+  );
+}


### PR DESCRIPTION
- Add links to Twitter, GitHub, Zenn, and Tech blog in the footer.
- Include Rakuten credit in line with partnership terms.

Closes #9